### PR TITLE
Used view binding in viewholder generation

### DIFF
--- a/src/main/kotlin/com/cookpad/astemplates/recipes/screen/adapter.kt
+++ b/src/main/kotlin/com/cookpad/astemplates/recipes/screen/adapter.kt
@@ -15,6 +15,7 @@ fun adapter(packageName: String, screenName: String) : String {
         import ${packageName}.R
         import ${packageName}.${screenName.toLowerCase()}.data.${screenName}
         import ${packageName}.${screenName.toLowerCase()}.${screenName}ViewHolder
+        import ${packageName}.databinding.Item${screenName}Binding
         
         class ${screenName}Adapter(
             paginatorStates: LiveData<PageState<${screenName}>>
@@ -25,8 +26,8 @@ fun adapter(packageName: String, screenName: String) : String {
             }
         
             override fun handleOnCreateViewHolder(parent: ViewGroup, viewType: Int): ${screenName}ViewHolder {
-                val root = LayoutInflater.from(parent.context).inflate(R.layout.item_${screenName.toLowerCase()}, parent, false)
-                return ${screenName}ViewHolder(root)
+                val binding = Item${screenName}Binding.inflate(LayoutInflater.from(parent.context), parent, false)
+                return ${screenName}ViewHolder(binding)
             }
         
             companion object {

--- a/src/main/kotlin/com/cookpad/astemplates/recipes/screen/viewHolder.kt
+++ b/src/main/kotlin/com/cookpad/astemplates/recipes/screen/viewHolder.kt
@@ -8,9 +8,9 @@ fun viewHolder(packageName: String, screenName: String): String {
         import kotlinx.android.extensions.LayoutContainer
         import androidx.recyclerview.widget.RecyclerView
         import ${packageName}.${screenName.toLowerCase()}.data.${screenName}
+        import ${packageName}.databinding.Item${screenName}Binding
         
-        class ${screenName}ViewHolder(override val containerView: View) : RecyclerView.ViewHolder(containerView),
-            LayoutContainer {
+        class ${screenName}ViewHolder(private val binding: Item${screenName}Binding) : RecyclerView.ViewHolder(binding.root) {
         
             fun bind(${screenName.toLowerCase()}: ${screenName}) {
         


### PR DESCRIPTION
This PR uses view binding while creating view holder instead of passing the view.

Issue: https://github.com/cookpad/android-studio-templates/issues/2